### PR TITLE
Chore: Remove Jest as production dependency and make dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "eslint": "^7.20.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.22.1",
+    "jest": "^26.6.3",
     "nodemon": "^2.0.7"
   },
   "dependencies": {
-    "express": "^4.17.1",
-    "jest": "^26.6.3"
+    "express": "^4.17.1"
   }
 }


### PR DESCRIPTION
FSA2021-53

## Description
Accidentally added Jest as a production dependency, not a dev dependency

## Spec

See Issue: [FSA2021-53](https://sparkbox.atlassian.net/browse/FSA2021-53)

## Validation
<!-- delete anything irrelevant to this PR -->

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Navigate to `chore--convert-jest-to-devdependency`
4. Open the package.json file to confirm that the only dev dependency is Express
5. Re-run tests by downloading the test patch file [test-patch.zip](https://github.com/sparkbox/apprentice-tic-tac-toe/files/6071625/test-patch.zip) and running `git apply (test location)` (i.e. `git apply ~/Desktop/test-patch.zip`), then running `npm test` and `npm run lint`.
6. ***Do not*** commit any changes with the patch files.
