### PR TITLE
Feat  add 404 page

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,12 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'src/html/index.html'));
 });
 
+app.use((req, res) => {
+  res
+    .status(404)
+    .sendFile(path.join(__dirname, 'src/html/404.html'));
+});
+
 app.listen(PORT, () => {
   console.log(`Example app listening at http://localhost:${PORT}`);
 });

--- a/src/html/404.html
+++ b/src/html/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>404 Not Found</title>
+</head>
+<body>
+  404 Not Found
+</body>
+</html>


### PR DESCRIPTION
## Description
The current version of the app shows only a message saying "Cannot GET /askldj" if you typed in a route that doesn't exist, for example http://localhost:3000/askldj. This PR displays a more helpful 404 status code and 404 page to tell the user that the resource has not been found.

## Spec

See Issue: [73](https://sparkbox.atlassian.net/browse/FSA2021-73)

## Validation
<!-- delete anything irrelevant to this PR -->

- [ ] This PR has code changes, and our linters still pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Navigate to http://localhost:3000/ and verify that you see tic-tac-toe
2. Navigate to a nonexistent url like http://localhost:3000/bleh and verify that you see both '404 not found' on the page in the browser and also a 404 status error in the console/network panel when inspecting the page

You should see something like this in the console:
![Screen Shot 2021-03-05 at 10 52 32 AM](https://user-images.githubusercontent.com/54716846/110141061-c4829c00-7da2-11eb-8b81-2b9e7ba4d84f.png)

Or in the network panel (you might have to refresh to see it properly):
![image](https://user-images.githubusercontent.com/54716846/110141152-dfeda700-7da2-11eb-99b6-093667be934b.png)


