### PR TITLE
Feat - add player to subheader

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <h1 class="header">Tic Tac Toe</h1>
-  <h2 class="subheader">No winner yet!</h2>
+  <h2 class="subheader"></h2>
   <div class="game-grid">
     <div class="grid-cell util-no-top-border util-no-left-border"></div>
     <div class="grid-cell util-no-top-border"></div>

--- a/src/js/Game/game.js
+++ b/src/js/Game/game.js
@@ -12,9 +12,13 @@ export class Game {
 
 const game = new Game();
 
-export function handleClickCell(cell, currGame = game) {
+export function handleClickCell(cell, subheading, currGame = game) {
   if (cell.innerText) return;
   // eslint-disable-next-line no-param-reassign
   cell.innerText = currGame.currentPlayer;
   currGame.nextPlayer();
+  if (subheading) {
+    // eslint-disable-next-line no-param-reassign
+    subheading.innerText = `It's ${currGame.currentPlayer}'s turn`;
+  }
 }

--- a/src/js/Game/game.js
+++ b/src/js/Game/game.js
@@ -1,4 +1,4 @@
-class Game {
+export class Game {
   constructor() {
     this.currentPlayer = 'X';
     this.winner = null;
@@ -10,11 +10,11 @@ class Game {
   }
 }
 
-export const game = new Game();
+const game = new Game();
 
-export function handleClickCell(cell) { // 68
+export function handleClickCell(cell, currGame = game) {
   if (cell.innerText) return;
   // eslint-disable-next-line no-param-reassign
-  cell.innerText = game.currentPlayer;
-  game.nextPlayer();
+  cell.innerText = currGame.currentPlayer;
+  currGame.nextPlayer();
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,5 +3,10 @@ import { handleClickCell } from './Game/game.js';
 
 console.debug('Welcome to Tic Tac Toe!');
 
+// eslint-disable-next-line no-undef
+const subheader = document.querySelector('.subheader');
+// eslint-disable-next-line quotes
+subheader.innerText = (`It's X's turn`);
+// eslint-disable-next-line no-undef
 const allGameCells = document.querySelectorAll('.grid-cell');
-allGameCells.forEach((cell) => cell.addEventListener('click', () => { handleClickCell(cell); }));
+allGameCells.forEach((cell) => cell.addEventListener('click', () => { handleClickCell(cell, subheader); }));

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -96,20 +96,31 @@ describe('Toggling between Xs and Os', () => {
 });
 
 describe.only('subheader text', () => {
-  // mock up h2 and mock up adding inner text
-  const subheaderDom = new JSDOM(`<h2 class="subheader"></h2>`);
-  const subheader = subheaderDom.window.document.querySelector('.subheader');
-  subheader.innerText = `It's X's turn`;
-  // mocking single grid cell
-  const gridCellDom = new JSDOM(`<div class="grid-cell"></div>`);
-  const gridCell = gridCellDom.window.document.querySelector('.grid-cell');
-  gridCell.addEventListener('click', () => { handleClickCell(gridCell, subheader); });
-  state.currentTurn = 'X';
+  let ticTacToeDom;
+  let game;
+  let allGridCells;
+  let subheader;
+  beforeEach(() => {
+    ticTacToeDom = createSubheaderAndGrid();
+    subheader = ticTacToeDom.window.document.querySelector('.subheader');
+    subheader.innerText = (`It's X's turn`);
+    game = new Game();
+    allGridCells = ticTacToeDom.window.document.querySelectorAll('.grid-cell');
+    addHandleClickListener(allGridCells, subheader, game);
+  });
   it(`shows X's turn in subheader at the beginning of the game`, () => {
     expect(subheader.innerText).toBe(`It's X's turn`);
   });
   it(`shows O's turn in subheader after first turn`, () => {
-    handleClickCell(gridCell, subheader);
+    const gridCell = ticTacToeDom.window.document.querySelector('.grid-cell');
+    gridCell.click();
     expect(subheader.innerText).toBe(`It's O's turn`);
+  });
+  it(`show's X's turn in subheader after two turns`, () => {
+    const firstGridCell = ticTacToeDom.window.document.querySelectorAll('.grid-cell')[0];
+    const secondGridCell = ticTacToeDom.window.document.querySelectorAll('.grid-cell')[1];
+    firstGridCell.click();
+    secondGridCell.click();
+    expect(subheader.innerText).toBe(`It's X's turn`);
   });
 });

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -1,5 +1,6 @@
+/* eslint-disable quotes */
 import jsdom from 'jsdom';
-import { handleClickCell, game } from './Game/game';
+import { handleClickCell, Game } from './Game/game';
 
 const { JSDOM } = jsdom;
 
@@ -15,6 +16,23 @@ function ticTacToeUI() {
 <div class="grid-cell util-no-bottom-border"></div>
 <div class="grid-cell util-no-bottom-border util-no-right-border"></div>
 </div>
+`);
+}
+
+function createSubheaderAndGrid() {
+  return new JSDOM(`
+  <h2 class="subheader"></h2>
+  <div class="game-grid">
+    <div class="grid-cell util-no-top-border util-no-left-border"></div>
+    <div class="grid-cell util-no-top-border"></div>
+    <div class="grid-cell util-no-top-border util-no-right-border"></div>
+    <div class="grid-cell util-no-left-border"></div>
+    <div class="grid-cell"></div>
+    <div class="grid-cell util-no-right-border"></div>
+    <div class="grid-cell util-no-bottom-border util-no-left-border"></div>
+    <div class="grid-cell util-no-bottom-border"></div>
+    <div class="grid-cell util-no-bottom-border util-no-right-border"></div>
+  </div>
 `);
 }
 
@@ -75,4 +93,23 @@ describe('Toggling between Xs and Os', () => {
       });
     }
   }
+});
+
+describe.only('subheader text', () => {
+  // mock up h2 and mock up adding inner text
+  const subheaderDom = new JSDOM(`<h2 class="subheader"></h2>`);
+  const subheader = subheaderDom.window.document.querySelector('.subheader');
+  subheader.innerText = `It's X's turn`;
+  // mocking single grid cell
+  const gridCellDom = new JSDOM(`<div class="grid-cell"></div>`);
+  const gridCell = gridCellDom.window.document.querySelector('.grid-cell');
+  gridCell.addEventListener('click', () => { handleClickCell(gridCell, subheader); });
+  state.currentTurn = 'X';
+  it(`shows X's turn in subheader at the beginning of the game`, () => {
+    expect(subheader.innerText).toBe(`It's X's turn`);
+  });
+  it(`shows O's turn in subheader after first turn`, () => {
+    handleClickCell(gridCell, subheader);
+    expect(subheader.innerText).toBe(`It's O's turn`);
+  });
 });

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -4,22 +4,8 @@ import { handleClickCell, Game } from './Game/game';
 
 const { JSDOM } = jsdom;
 
-function ticTacToeUI() {
-  return new JSDOM(`<div class="game-grid">
-<div class="grid-cell util-no-top-border util-no-left-border"></div>
-<div class="grid-cell util-no-top-border"></div>
-<div class="grid-cell util-no-top-border util-no-right-border"></div>
-<div class="grid-cell util-no-left-border"></div>
-<div class="grid-cell"></div>
-<div class="grid-cell util-no-right-border"></div>
-<div class="grid-cell util-no-bottom-border util-no-left-border"></div>
-<div class="grid-cell util-no-bottom-border"></div>
-<div class="grid-cell util-no-bottom-border util-no-right-border"></div>
-</div>
-`);
-}
-
-function createSubheaderAndGrid() {
+// helper function to create the mock tic-tac-toe UI used in the tests
+function createTicTacToeUI() {
   return new JSDOM(`
   <h2 class="subheader"></h2>
   <div class="game-grid">
@@ -36,89 +22,94 @@ function createSubheaderAndGrid() {
 `);
 }
 
+// helper function to add event listeners to cells
+function addHandleClickListener(cells, subheader, game) {
+  cells.forEach((cell) => cell.addEventListener('click', () => { handleClickCell(cell, subheader, game); }));
+}
+
 describe('Handle click cell function', () => {
-  const gridGame = ticTacToeUI();
-  // As there are multiple grid cell elements, this will only select the first one.
-  const gridCell = gridGame.window.document.querySelector('.grid-cell');
-  const allGameCells = gridGame.window.document.querySelectorAll('.grid-cell');
+  let gridGame;
+  let game;
+  let singleGridCell;
+  let allGridCells;
+  let subheader; // not ever defined or used, but needed to pass into handleClickCell
   beforeEach(() => {
-    allGameCells.forEach((cell) => cell.addEventListener('click', () => { handleClickCell(cell); }));
-  });
-  afterEach(() => {
-    allGameCells.forEach((cell) => {
-      // eslint-disable-next-line no-param-reassign
-      cell.innerText = '';
-    });
-    game.currentPlayer = 'X';
+    gridGame = createTicTacToeUI();
+    game = new Game();
+    // As there are multiple grid cell elements, this will only select the first one.
+    singleGridCell = gridGame.window.document.querySelector('.grid-cell');
+    allGridCells = gridGame.window.document.querySelectorAll('.grid-cell');
+    addHandleClickListener(allGridCells, subheader, game);
   });
   it('Shows an empty grid cell before any choices have been made', () => {
-    expect(gridCell.textContent).toBe('');
+    expect(singleGridCell.textContent).toBe('');
   });
   it('Marks a grid cell with an "X" using the handleClickCell function directly', () => {
-    handleClickCell(gridCell);
-    expect(gridCell.innerText).toBe('X');
+    handleClickCell(singleGridCell, subheader, game);
+    expect(singleGridCell.innerText).toBe('X');
   });
   it('Marks a grid cell with an "X" by clicking', () => {
-    gridCell.click();
-    expect(gridCell.innerText).toBe('X');
+    singleGridCell.click();
+    expect(singleGridCell.innerText).toBe('X');
   });
   it('Does not mark a grid that has been marked already', () => {
-    gridCell.click();
-    const click1 = gridCell;
-    gridCell.click();
-    const click2 = gridCell;
-    expect(click1.innerText).toEqual('X');
-    expect(click2.innerText).toEqual('X');
+    singleGridCell.click();
+    const click1GridContent = singleGridCell.innerText;
+    singleGridCell.click();
+    const click2GridContent = singleGridCell.innerText;
+    expect(click1GridContent).toEqual('X');
+    expect(click2GridContent).toEqual('X');
   });
 });
 
 describe('Toggling between Xs and Os', () => {
-  const gridGame = ticTacToeUI();
-  // As there are multiple grid cell elements, this will only select the first one.
-  const allGameCells = gridGame.window.document.querySelectorAll('.grid-cell');
-  allGameCells.forEach((cell) => cell.addEventListener('click', () => { handleClickCell(cell); }));
+  const gridGame = createTicTacToeUI();
+  const game = new Game();
+  const allGridCells = gridGame.window.document.querySelectorAll('.grid-cell');
+  let subheader; // not ever defined or used, but needed to pass into handleClickCell
+  addHandleClickListener(allGridCells, subheader, game);
   // The following for loop will go through and click each cell in the game grid.
   // It will click each cell only once, so a cell will go from blank to either an X or an O,
   // depending on whether the click is even (0, 2, 4, 6, 8) or odd (1, 3, 5, 7).
-  for (let i = 0; i < allGameCells.length; i += 1) {
-    allGameCells[i].click();
+  for (let i = 0; i < allGridCells.length; i += 1) {
+    allGridCells[i].click(); // Simulate clicking each cell in order from index 0 to 8
     // As indexes are zero based, zero will be counted as even.
     if (i % 2 === 0) {
       it(`Shows that a click on a previously unclicked cell will produce an x if said click is an even number (click #${i})`, () => {
-        expect(allGameCells[i].innerText).toBe('X');
+        expect(allGridCells[i].innerText).toBe('X');
       });
     } else {
       it(`Shows that a click on a previously unclicked cell will produce an o if said click is an odd number (click #${i})`, () => {
-        expect(allGameCells[i].innerText).toBe('O');
+        expect(allGridCells[i].innerText).toBe('O');
       });
     }
   }
 });
 
-describe.only('subheader text', () => {
-  let ticTacToeDom;
+describe('subheader text', () => {
+  let gridGame;
   let game;
   let allGridCells;
   let subheader;
   beforeEach(() => {
-    ticTacToeDom = createSubheaderAndGrid();
-    subheader = ticTacToeDom.window.document.querySelector('.subheader');
+    gridGame = createTicTacToeUI();
+    subheader = gridGame.window.document.querySelector('.subheader');
     subheader.innerText = (`It's X's turn`);
     game = new Game();
-    allGridCells = ticTacToeDom.window.document.querySelectorAll('.grid-cell');
+    allGridCells = gridGame.window.document.querySelectorAll('.grid-cell');
     addHandleClickListener(allGridCells, subheader, game);
   });
   it(`shows X's turn in subheader at the beginning of the game`, () => {
     expect(subheader.innerText).toBe(`It's X's turn`);
   });
   it(`shows O's turn in subheader after first turn`, () => {
-    const gridCell = ticTacToeDom.window.document.querySelector('.grid-cell');
+    const gridCell = gridGame.window.document.querySelector('.grid-cell');
     gridCell.click();
     expect(subheader.innerText).toBe(`It's O's turn`);
   });
   it(`show's X's turn in subheader after two turns`, () => {
-    const firstGridCell = ticTacToeDom.window.document.querySelectorAll('.grid-cell')[0];
-    const secondGridCell = ticTacToeDom.window.document.querySelectorAll('.grid-cell')[1];
+    const firstGridCell = gridGame.window.document.querySelectorAll('.grid-cell')[0];
+    const secondGridCell = gridGame.window.document.querySelectorAll('.grid-cell')[1];
     firstGridCell.click();
     secondGridCell.click();
     expect(subheader.innerText).toBe(`It's X's turn`);


### PR DESCRIPTION
## Description
Now that we have support for toggling between Xs and Os, our application is aware of whose turn it is in the game. To make this clear to our users, we should update our subheader to show variable text that tells our players whose turn it is.

## Spec

See Issue: [71](https://sparkbox.atlassian.net/browse/FSA2021-71)

## Validation
<!-- delete anything irrelevant to this PR -->

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Navigate to http://localhost:3000/ and run `npm start` on the app
2. Verify that the subheader text initially is "It's X's turn" then toggles to "It's O's turn" and back again, depending on the player's turn.
3. Verify that tests pass and linter is happy.
