### PR TITLE
Feat  auto update version number

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,10 @@ module.exports = {
     'no-console': 'off',
     'no-debugger': 'off',
   },
+  globals: {
+    fetch: false,
+    document: false,
+  },
   overrides: [
     {
       files: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2941,6 +2941,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cross-fetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.0.tgz",
+      "integrity": "sha512-a+yso9lSpXQI9DH+YjAu/m0dVfP8IVoZDPBLLFcvGpeq3KHNdikkekTOdkHiXEuTq4GBOeO0MfWkE40yzF1w7g==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5137,6 +5146,16 @@
         "jest-util": "^26.6.2"
       }
     },
+    "jest-fetch-mock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
+      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      }
+    },
     "jest-get-type": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
@@ -6116,6 +6135,12 @@
         }
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -6688,6 +6713,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.0.tgz",
+      "integrity": "sha512-k/TC0mIcPVF6yHhUvwAp7cvL6I2fFV7TzF1DuGPI8mBh4QQazf36xCKEHKTZKRysEoTQoQdKyP25J8MPJp7j5g==",
       "dev": true
     },
     "prompts": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-config-airbnb": "^18.2.1",
     "eslint-plugin-import": "^2.22.1",
     "jest": "^26.6.3",
+    "jest-fetch-mock": "^3.0.3",
     "jsdom": "^16.5.0",
     "nodemon": "^2.0.7"
   },

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import express from 'express';
 import path from 'path';
+import pkg from './package.json';
 
 const app = express();
 const PORT = 3000;
@@ -8,6 +9,12 @@ const PORT = 3000;
 app.use(express.static(path.join(__dirname, 'src')));
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'src/html/index.html'));
+});
+
+app.get('/version', (req, res) => {
+  res.json(
+    pkg.version,
+  );
 });
 
 app.use((req, res) => {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,6 @@
-// eslint-disable-next-line import/extensions
+/* eslint-disable import/extensions */
 import { handleClickCell } from './Game/game.js';
+import { updateVersionNumber } from './version.js';
 
 console.debug('Welcome to Tic Tac Toe!');
 
@@ -10,3 +11,7 @@ subheader.innerText = (`It's X's turn`);
 // eslint-disable-next-line no-undef
 const allGameCells = document.querySelectorAll('.grid-cell');
 allGameCells.forEach((cell) => cell.addEventListener('click', () => { handleClickCell(cell, subheader); }));
+
+const appVersion = document.querySelector('.app-version_version');
+
+updateVersionNumber(appVersion);

--- a/src/js/index.spec.js
+++ b/src/js/index.spec.js
@@ -1,6 +1,10 @@
 /* eslint-disable quotes */
+import { enableFetchMocks } from 'jest-fetch-mock';
 import jsdom from 'jsdom';
 import { handleClickCell, Game } from './Game/game';
+import { getVersionNumber, updateVersionNumber } from './version';
+
+enableFetchMocks();
 
 const { JSDOM } = jsdom;
 
@@ -113,5 +117,23 @@ describe('subheader text', () => {
     firstGridCell.click();
     secondGridCell.click();
     expect(subheader.innerText).toBe(`It's X's turn`);
+  });
+});
+
+describe('Show the current version number', () => {
+  it('Returns a current version of 1.0.0', async () => {
+    fetch.mockResponseOnce(JSON.stringify('1.0.0'));
+    const versionNumber = await getVersionNumber();
+    expect(versionNumber).toBe('1.0.0');
+  });
+  it('Shows the source URL for the current version', async () => {
+    expect(fetch.mock.calls[0][0]).toEqual('./version');
+  });
+  it('Shows the version number is 1.0.0 on the Tic Tac Toe page', async () => {
+    const versionNumberDom = new JSDOM('<h2 class="app-version">Version <span class="app-version_version">0.0.1</span></h2>');
+    const appVersion = versionNumberDom.window.document.querySelector('.app-version_version');
+    fetch.mockResponseOnce(JSON.stringify('1.0.0'));
+    await updateVersionNumber(appVersion);
+    expect(appVersion.innerText).toBe('1.0.0');
   });
 });

--- a/src/js/version.js
+++ b/src/js/version.js
@@ -1,0 +1,9 @@
+export async function getVersionNumber() {
+  const response = await fetch('./version');
+  const versionNumber = await response.json();
+  return versionNumber;
+}
+export async function updateVersionNumber(versionText) {
+  // eslint-disable-next-line no-param-reassign
+  versionText.innerText = await getVersionNumber();
+}


### PR DESCRIPTION
## Description
The package number on index.html will now update whenever the package number in package.json is updated.
To implement this, I imported the package.json file into the server file, used it to create a variable, passed that variable as JSON data to a new route (/version), created an asynchronous function to retrieve the data from the version route, and created another function to update the UI.

## Spec

See Issue: [FSA2021-65](https://sparkbox.atlassian.net/browse/FSA2021-65)

## Validation
<!-- delete anything irrelevant to this PR -->

- ✔️  This PR has code changes, and our linters still pass.
- ✔️  This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
2. Pull down all related branches.
3. Navigate to `feat--auto-update-version-number`. Run `npm test`.
4. Change the version number in the package.json file. Run `npm start` and navigate to [localhost:3000/version](http://localhost:3000/version) and [localhost:3000](http://localhost:3000) to confirm that the package number matches.